### PR TITLE
chore: Configure package.json in packageFiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "packageFiles": ["package.json"],
   "automerge": "minor",
   "depTypes": [
     {


### PR DESCRIPTION
By explicitly listing `packageFiles` in the `renovate.json` it will help Renovate know not to attempt to parse the template in `src/templates/package.json`. It doesn't really cause you any problem to leave it as-is, because Renovate will skip over any invalid `package.json` files, but it raises an error to me each time and I'd like to get rid of it!